### PR TITLE
chore: bump version to 0.5.6

### DIFF
--- a/lib/stream/version.rb
+++ b/lib/stream/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Stream
-  VERSION = '0.5.5'
+  VERSION = '0.5.6'
 end


### PR DESCRIPTION
## Summary

release-please updated `CHANGELOG.md` and created tag `v0.5.6` but did not update `lib/stream/version.rb`. This fixes the version file so the gem can be published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)